### PR TITLE
[NFC] Add default code block language

### DIFF
--- a/Sources/WWDCNotes/WWDCNotes.docc/Info.plist
+++ b/Sources/WWDCNotes/WWDCNotes.docc/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>WWDCNotes</string>
+	<key>CFBundleDisplayName</key>
+	<string>WWDCNotes</string>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
+</dict>
+</plist>

--- a/Sources/WWDCNotes/WWDCNotes.docc/WWDC21/WWDC21-10212-Analyze-HTTP-traffic-in-Instruments-.md
+++ b/Sources/WWDCNotes/WWDCNotes.docc/WWDC21/WWDC21-10212-Analyze-HTTP-traffic-in-Instruments-.md
@@ -42,7 +42,7 @@ session.sessionDescription = "Main Session"
 
 - Structural timing from start till the end
 
-```
+```swift
 let task = session.dataTask(with: url) {
   /* handle result */ // 👈🏻 Complete event triggers here
 }

--- a/Sources/WWDCNotes/WWDCNotes.docc/WWDC24/WWDC24-10135-Whats-new-in-Xcode-16.md
+++ b/Sources/WWDCNotes/WWDCNotes.docc/WWDC24/WWDC24-10135-Whats-new-in-Xcode-16.md
@@ -148,7 +148,7 @@ func plantingRoses() {
 
 Tests can be in suites and have a list of inputs:
 
-```
+```swift
 import Testing
 @testable import BOTanist
 


### PR DESCRIPTION
- **Add Info.plist to make swift the default language for code block**
- **Fix missing language for code block**

Some contributor forgot to set the language to `swift` explicitly for Swift code block.

Consider most of the code block is Swift code here, we may set the default/implicit code block language to Swift via a Info.plist file supported by DocC.


Info.plist Key | Description
-- | --
CFBundleDisplayName | The display name of the bundle.
CFBundleIdentifier | The unique identifier of the bundle.
CFBundleVersion | The version of the bundle.
CDDefaultCodeListingLanguage | The default language identifier for code listings in the bundle.
CDAppleDefaultAvailability | The default availability for the various modules in the bundle.