### PR TITLE
Fix: Handle GitHub user 404 breaking CI builds

### DIFF
--- a/Sources/generate-metadata/main.swift
+++ b/Sources/generate-metadata/main.swift
@@ -8,7 +8,7 @@ import FoundationNetworking
 
 struct Contributor {
    struct GitHubUser: Codable {
-      let id: Int
+      let id: Int?
       let name: String?
       let bio: String?
       let blog: String?
@@ -74,11 +74,11 @@ struct Contributor {
 
       let fullNameTokens = self.fullName.components(separatedBy: .whitespaces)
 
-      if gitHubUser.avatarUrl != nil {
+      if gitHubUser.avatarUrl != nil, let githubUserID = gitHubUser.id {
          var urlComponents = URLComponents()
          urlComponents.scheme = "https"
          urlComponents.host = "avatars.githubusercontent.com"
-         urlComponents.path = "/u/\(gitHubUser.id)"
+         urlComponents.path = "/u/\(githubUserID)"
          urlComponents.queryItems = [URLQueryItem(name: "v", value: "4")]
 
          self.avatarURL = urlComponents.url!


### PR DESCRIPTION
Fixes a runtime error when generating metadata for a GitHub user that throws a 404 error.

Example logs:

```text
Fetching GitHub profile details for '<USERNAME>'…
Fetched contents were: {"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}
Swift/ErrorType.swift:254: Fatal error: Error raised at top level: Swift.DecodingError.keyNotFound(CodingKeys(stringValue: "id", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"id\", intValue: nil) (\"id\").", underlyingError: nil))
```